### PR TITLE
Wrap debug logging with toggleable utility

### DIFF
--- a/src/modules/article-details/ArticleDetails.tsx
+++ b/src/modules/article-details/ArticleDetails.tsx
@@ -35,6 +35,7 @@ import { getCurrentUser } from '../../utils/auth';
 import type { User } from '@supabase/supabase-js';
 import EditIcon from '@mui/icons-material/Edit';
 import { toast, ToastContainer } from 'react-toastify';
+import { debugLog } from '../../utils/debug';
 
 // Define the comment type
 // interface Comment {
@@ -83,7 +84,7 @@ const ArticleDetails: React.FC = () => {
       return null;
     }
 
-    console.log("data in fetchComments", data)
+    debugLog("data in fetchComments", data)
     return data || null;
   };
 
@@ -171,7 +172,7 @@ const ArticleDetails: React.FC = () => {
       toast.error("Logged in to like");
     }
     else {
-      console.log(data);
+      debugLog(data);
       queryClient.invalidateQueries({ queryKey: ['article_reaction_counts', article.id] });
     }
   };
@@ -189,7 +190,7 @@ const ArticleDetails: React.FC = () => {
       toast.error("Logged in to dislike");
     }
     else {
-      console.log(data);
+      debugLog(data);
       queryClient.invalidateQueries({ queryKey: ['article_reaction_counts', article.id] });
     }
   };
@@ -250,13 +251,13 @@ const ArticleDetails: React.FC = () => {
     if (error) {
       console.error('Error adding comment:', error.message);
     } else {
-      console.log(data);
+      debugLog(data);
     }
     setNewComment('');
     queryClient.invalidateQueries({ queryKey: ['comments', article.id] });
   };
-  console.log("user in section", user)
-  console.log("comments in section", comments)
+  debugLog("user in section", user)
+  debugLog("comments in section", comments)
   return (
     <div className="article-details">
       {/* Back Button */}

--- a/src/modules/articles/Articles.tsx
+++ b/src/modules/articles/Articles.tsx
@@ -11,6 +11,7 @@ import type { User } from '@supabase/supabase-js';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../supabaseClient';
 import Loading from '../../shared/loading/Loading';
+import { debugLog } from '../../utils/debug';
 
 const Articles: React.FC = () => {
   const { t } = useTranslation();
@@ -38,7 +39,7 @@ const { data: articles, isLoading } = useQuery({
   queryFn: () => getArticles(),
 })
 
- console.log(articles)
+  debugLog(articles)
   return (
     <div className="articles">
       {user && (

--- a/src/modules/articles/components/ArticlesCard.tsx
+++ b/src/modules/articles/components/ArticlesCard.tsx
@@ -9,6 +9,7 @@ import { supabase } from '../../../supabaseClient';
 import Loading from '../../../shared/loading/Loading';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
+import { debugLog } from '../../../utils/debug';
 
 interface ArticleData {
     title: string;
@@ -60,7 +61,7 @@ const ArticlesCard = ({ article }: { article: ArticleData }) => {
         queryFn: () => getAuthorProfile(),
         refetchOnWindowFocus: false
     })
-    console.log(authorProfile)
+    debugLog(authorProfile)
 
     if (isLoading) {
         return <Loading message="Loading article..." />

--- a/src/modules/articles/components/add-article/AddArticle.tsx
+++ b/src/modules/articles/components/add-article/AddArticle.tsx
@@ -24,12 +24,13 @@ import { toast, ToastContainer } from 'react-toastify';
 import { detect} from "tinyld";
 import { ROUTES } from '../../../../routes/pathes';
 import { useNavigate } from 'react-router-dom';
+import { debugLog } from '../../../../utils/debug';
 
 const code = detect("هذا نص عربي");     // -> "ar"
 const top3 = detect("Hello world ");
 //  const english = code || top3;
-console.log(code)
-console.log(top3)
+debugLog(code)
+debugLog(top3)
 
 const addArticleSchema = z.object({
   title: z.string().min(1, 'Title is required'),
@@ -46,7 +47,7 @@ const AddArticle: React.FC = () => {
   const [user, setUser] = useState<User | null>(null);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  console.log(user)
+  debugLog(user)
   useEffect(() => {
     getCurrentUser().then((data: User | null) => setUser(data))
   }, [])
@@ -85,7 +86,7 @@ const AddArticle: React.FC = () => {
   const { mutate, } = useMutation({
     mutationFn: addArticle,
     onSuccess: (data) => {
-      console.log(data);
+      debugLog(data);
       toast.success('Article added successfully', {
         position: "top-right",
         autoClose: 5000,
@@ -120,7 +121,7 @@ const AddArticle: React.FC = () => {
     }
    
     const code = detect(dataForm.content);
-    console.log(code)
+    debugLog(code)
     mutate(dataForm);
     navigate(ROUTES.ARTICLS);
   };

--- a/src/modules/auth/Auth.tsx
+++ b/src/modules/auth/Auth.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import './Auth.scss';
+import { debugLog } from '../../utils/debug';
 
 const Auth: React.FC = () => {
-  console.log('Auth');
+  debugLog('Auth');
   return (
     <div className="auth">
       <h1>Authentication</h1>

--- a/src/modules/auth/login/login.tsx
+++ b/src/modules/auth/login/login.tsx
@@ -19,6 +19,7 @@ import { ROUTES } from '../../../routes/pathes';
 import './login.scss';
 import { useMutation } from '@tanstack/react-query';
 import { toast, ToastContainer } from 'react-toastify';
+import { debugLog } from '../../../utils/debug';
 
 // Zod validation schema
 const loginSchema = z.object({
@@ -44,7 +45,7 @@ const Login: React.FC = () => {
   });
 
   const handelsignIn = async (data: LoginFormData) => {
-  console.log("handelsignIn");
+  debugLog("handelsignIn");
     const { data: dataSignIn, error } = await supabase.auth.signInWithPassword(data);
     if (error) {
       throw error;
@@ -55,7 +56,7 @@ const Login: React.FC = () => {
   }
 
   const handleForgotPassword = async (email: string) => {
-    console.log("handleForgotPassword");
+    debugLog("handleForgotPassword");
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: `${window.location.origin}/reset-password`,
     });
@@ -64,11 +65,11 @@ const Login: React.FC = () => {
     }
   }
 
-  console.log(window.location.origin);
+  debugLog(window.location.origin);
   const { mutate, isPending} = useMutation({
     mutationFn: handelsignIn,
     onSuccess: (data) => {
-      console.log(data);
+      debugLog(data);
       navigate(ROUTES.PROFILE);
       toast.success('Login successful');
     },

--- a/src/modules/auth/signup/signup.tsx
+++ b/src/modules/auth/signup/signup.tsx
@@ -23,6 +23,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import './signup.scss'; 
 import { ROUTES } from '../../../routes/pathes';
 import { useNavigate } from 'react-router-dom';
+import { debugLog } from '../../../utils/debug';
 
 // Zod validation schema
 const signupSchema = z.object({
@@ -54,7 +55,7 @@ const Signup: React.FC = () => {
   });
 
   const onSubmit = async (dataForm: SignupFormData) => {
-    console.log('Signup data:', dataForm);
+    debugLog('Signup data:', dataForm);
     const { data, error } = await supabase.auth.signUp({...dataForm, options: {
       data: {
         username: dataForm.username,
@@ -65,9 +66,9 @@ const Signup: React.FC = () => {
     if (error) {
       console.error('Error signing up:', error.message)
     } else {
-      console.log(data);
+      debugLog(data);
       if (data.user?.identities?.length === 0) {
-        console.log('User already exists');
+        debugLog('User already exists');
         setOpenErrorModal(true);
       }
       else {

--- a/src/modules/philosopher-details/PhilosopherDetails.tsx
+++ b/src/modules/philosopher-details/PhilosopherDetails.tsx
@@ -10,6 +10,7 @@ import { supabase } from '../../supabaseClient';
 import { useQuery } from '@tanstack/react-query';
 import Loading from '../../shared/loading/Loading';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import { debugLog } from '../../utils/debug';
 
 const PhilosopherDetails: React.FC = () => {
   const { philosopher } = useLocation().state;
@@ -36,7 +37,7 @@ const PhilosopherDetails: React.FC = () => {
     queryFn: () => getPhilosopherBio(philosopher.id)
   })
 
-  console.log(philosopherBio)
+  debugLog(philosopherBio)
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/src/modules/philosophers/Philosophers.tsx
+++ b/src/modules/philosophers/Philosophers.tsx
@@ -22,6 +22,7 @@ import { supabase } from '../../supabaseClient';
 import { useDispatch, useSelector } from 'react-redux';
 import { setCurrentPage } from '../../store/reducers/paginationSlice';
 import type { AppDispatch, RootState } from '../../store';
+import { debugLog } from '../../utils/debug';
 // Define the philosopher type based on your Supabase table structure
 async function getPhilosophersPage(page: number, pageSize: number = 12) {
   const from = (page - 1) * pageSize;
@@ -67,7 +68,7 @@ const philosophers: React.FC = () => {
   // Fetch philosophers from Supabase
   const { data: PhilosophersData, isLoading, error } = usePhilosophers(currentPage, cardsPerPage);
 
-  console.log(PhilosophersData);
+  debugLog(PhilosophersData);
 
   // Calculate total pages based on filtered data
 

--- a/src/modules/profile/Profile.tsx
+++ b/src/modules/profile/Profile.tsx
@@ -8,6 +8,7 @@ import Loading from '../../shared/loading/Loading';
 import {ToastContainer } from 'react-toastify';
 import EditIcon from '@mui/icons-material/Edit';
 import { getCurrentUser} from '../../utils/auth';
+import { debugLog } from '../../utils/debug';
 const Profile: React.FC = () => {
 
     // state
@@ -116,7 +117,7 @@ const Profile: React.FC = () => {
     if(error || profile == null) {
         return <div>Error loading profile</div>
     }
-    console.log(profile?.full_name)
+    debugLog(profile?.full_name)
     return (
         <div className="profile">
             <Grid container spacing={2} className="profile__grid">

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import { supabase } from '../supabaseClient';
 import Loading from '../shared/loading/Loading';
+import { debugLog } from '../utils/debug';
 
 interface ProtectedRouteProps {
   redirectPath: string;
@@ -58,7 +59,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 
 
   if (!isAuthenticated) {
-    console.log('Not authenticated, redirecting to:', redirectPath);
+    debugLog('Not authenticated, redirecting to:', redirectPath);
     return <Navigate to={redirectPath} replace />;
   }
 

--- a/src/shared/layout/header/header.tsx
+++ b/src/shared/layout/header/header.tsx
@@ -16,6 +16,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import { supabase } from '../../../supabaseClient';
 import { AppBar, Toolbar, Avatar, IconButton, Typography, Menu, MenuItem, Drawer, List, ListItem, ListItemIcon, ListItemText, Divider } from "@mui/material";
 import { AccountCircle, Home, People, Article, School,  Logout, Login } from "@mui/icons-material";
+import { debugLog } from "../../../utils/debug";
 const Header: React.FC = () => {
   const lang = useSelector((state: RootState) => state.locale.lang);
   const { t } = useTranslation();
@@ -29,7 +30,7 @@ const Header: React.FC = () => {
     document.documentElement.setAttribute("lang", "ar");
     document.documentElement.setAttribute("dir", "rtl");
     dispatch(changeLang({ dir: "rtl", lang: "ar" }));
-    console.log(store.getState().locale);
+    debugLog(store.getState().locale);
   };
 
   const SetLangEn = () => {
@@ -55,7 +56,7 @@ const Header: React.FC = () => {
     if (error) {
       console.error('Error signing out:', error.message);
     } else {
-      console.log('User signed out successfully');
+      debugLog('User signed out successfully');
     }
     setSidebarOpen(false)
   }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabaseClient';
 import type { Session, User } from '@supabase/supabase-js';
+import { debugLog } from './debug';
 
 /**
  * Checks the current user session and returns session data if available
@@ -16,7 +17,7 @@ export async function checkSession(): Promise<Session | null> {
     if (data.session) {
         return data.session;
     } else {
-        console.log("No active session (user not logged in).");
+        debugLog("No active session (user not logged in).");
         return null;
     }
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,8 @@
+const isDebugEnabled =
+  import.meta.env.VITE_ENABLE_DEBUG === 'true' || import.meta.env.DEV;
+
+export const debugLog = (...args: unknown[]) => {
+  if (isDebugEnabled) {
+    console.log(...args);
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared `debugLog` helper that only prints when debugging is enabled
- replace direct `console.log` usage across routes, auth, articles, and layout components with the new helper so production builds stay quiet

## Testing
- npm run lint *(fails: existing lint errors about ts-ignore usage, unexpected any types, and lowercase component name in Philosophers.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c9113c9d64832c8fe528f5b2098ffe