### PR TITLE
Use env vars for Supabase client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Environment variables
+
+This project expects Supabase credentials to be available at build time. Create a `.env` file (or `.env.local`) in the project root with the following variables:
+
+```
+VITE_SUPABASE_URL=your-supabase-project-url
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+```
+
+The `VITE_` prefix makes these values available via `import.meta.env` in the client bundle.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,5 +1,14 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = 'https://uiurzngfvsytxftgyzln.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVpdXJ6bmdmdnN5dHhmdGd5emxuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ0NzM2NzksImV4cCI6MjA3MDA0OTY3OX0.5TQuwpnJe7dCMjeOF7I_r6U4V6bKhw-iUv66MssdFmw'
-export const supabase = createClient(supabaseUrl, supabaseKey)
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl) {
+  throw new Error('Missing VITE_SUPABASE_URL environment variable.')
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable.')
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- read Supabase connection details from the `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` environment variables
- guard against missing credentials when creating the Supabase client
- document the required Vite environment variables in the README

## Testing
- `CI=1 VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=public-anon-key npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c93969a784832c8a28f6c3ce37d14e